### PR TITLE
PB-427: Deploy til gcp med en minimal ktor applikasjon

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     team: min-side
 spec:
+  envFrom:
+    - secret: tms-personalia-api-secrets
   image: {{version}}
   port: 8080
   liveness:

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     team: min-side
 spec:
+  envFrom:
+    - secret: tms-personalia-api-secrets
   image: {{version}}
   port: 8080
   liveness:

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/bootstrap.kt
@@ -33,7 +33,9 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
     val config = this.environment.config
 
     install(Authentication) {
-        tokenValidationSupport(config = config)
+        basic {
+
+        }
     }
 
     install(ContentNegotiation) {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,7 +2,7 @@ ktor {
     deployment {
         port = 8101
         port = ${?PORT}
-        rootPath = "person/tms-personalia-api"
+        rootPath = "tms-personalia-api"
     }
 
     application {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,15 +9,3 @@ ktor {
         modules = [no.nav.personbruker.tms.personalia.api.config.BootstrapKt.mainModule]
     }
 }
-
-no.nav.security.jwt {
-    expirythreshold = 2 #threshold in minutes until token expires
-    issuers = [
-        {
-            issuer_name = "selvbetjening"
-            discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
-            accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
-            cookie_name = selvbetjening-idtoken
-        }
-    ]
-}


### PR DESCRIPTION
Har gjort noen tilpasninger for å få appen til å kjøre på gcp:

- Henter inn secrets fra tms-personalia-api-secrets slik at man leser inn miljøvariabler
- Fjernet konfig som ble brukt med tokensupport for autentisering 
- Fjernet /person fra rootPath

PB-427: Deploy til gcp med en minimal ktor applikasjon