### PR TITLE
Setter opp autentisering med tokenx

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
     implementation(Ktor.jackson)
     implementation(Ktor.serverNetty)
     implementation(DittNAV.Common.utils)
+    implementation(Tms.KtorTokenSupport.tokendingsExchange)
+    implementation(Tms.KtorTokenSupport.tokenXValidation)
     implementation(Logback.classic)
     implementation(Logstash.logbackEncoder)
     implementation(NAV.tokenValidatorKtor)
@@ -82,6 +84,8 @@ tasks {
         environment("LOGINSERVICE_IDPORTEN_DISCOVERY_URL", "http://localhost:9000/.well-known/openid-configuration")
         environment("LOGINSERVICE_IDPORTEN_AUDIENCE", "stubOidcClient")
         environment("OIDC_CLAIM_CONTAINING_THE_IDENTITY", "pid")
+        environment("TOKEN_X_CLIENT_ID", "...")
+        environment("TOKEN_X_WELL_KNOWN_URL", "...")
 
         environment("NAIS_CLUSTER_NAME", "dev-sbs")
         environment("NAIS_NAMESPACE", "personbruker")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,8 +84,6 @@ tasks {
         environment("LOGINSERVICE_IDPORTEN_DISCOVERY_URL", "http://localhost:9000/.well-known/openid-configuration")
         environment("LOGINSERVICE_IDPORTEN_AUDIENCE", "stubOidcClient")
         environment("OIDC_CLAIM_CONTAINING_THE_IDENTITY", "pid")
-        environment("TOKEN_X_CLIENT_ID", "...")
-        environment("TOKEN_X_WELL_KNOWN_URL", "...")
 
         environment("NAIS_CLUSTER_NAME", "dev-sbs")
         environment("NAIS_NAMESPACE", "personbruker")

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -23,6 +23,8 @@ spec:
     min: 2
     max: 4
   webproxy: true
+  tokenx:
+    enabled: true
   ingresses:
     - "https://person.dev.nav.no/tms-personalia-api"
   resources:

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -25,6 +25,12 @@ spec:
   webproxy: true
   tokenx:
     enabled: true
+  accessPolicy:
+    inbound:
+      rules:
+        - application: dittnav-api
+          namespace: personbruker
+          cluster: dev-sbs
   ingresses:
     - "https://person.dev.nav.no/tms-personalia-api"
   resources:

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -23,6 +23,8 @@ spec:
     min: 2
     max: 4
   webproxy: true
+  tokenx:
+    enabled: true
   ingresses:
     - "https://person.intern.nav.no/tms-personalia-api"
   resources:

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -25,6 +25,12 @@ spec:
   webproxy: true
   tokenx:
     enabled: true
+  accessPolicy:
+    inbound:
+      rules:
+        - application: dittnav-api
+          namespace: personbruker
+          cluster: prod-sbs
   ingresses:
     - "https://person.intern.nav.no/tms-personalia-api"
   resources:

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/ApplicationContext.kt
@@ -1,10 +1,13 @@
 package no.nav.personbruker.tms.personalia.api.config
 
 import no.nav.personbruker.tms.personalia.api.health.HealthService
+import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
 
 class ApplicationContext {
 
     val httpClient = HttpClientBuilder.build()
     val healthService = HealthService(this)
+
+    val tokendingsService = TokendingsServiceBuilder.buildTokendingsService(maxCachedEntries = 10000)
 
 }

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/Environment.kt
@@ -3,5 +3,5 @@ package no.nav.personbruker.tms.personalia.api.config
 import no.nav.personbruker.dittnav.common.util.config.StringEnvVar.getEnvVar
 
 data class Environment(
-    val corsAllowedOrigins: String = getEnvVar("CORS_ALLOWED_ORIGINS")
+    val corsAllowedOrigins: String = getEnvVar("CORS_ALLOWED_ORIGINS"),
 )

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/TokenDingsFetcher.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/TokenDingsFetcher.kt
@@ -1,0 +1,12 @@
+package no.nav.personbruker.tms.personalia.api.config
+
+import no.nav.tms.token.support.tokendings.exchange.TokendingsService
+
+class TokendingsTokenFetcher(
+    private val tokendingsService: TokendingsService,
+    private val PDLClientId: String
+) {
+    suspend fun getPDLToken(userToken: String): String {
+        return tokendingsService.exchangeToken(userToken, PDLClientId)
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/bootstrap.kt
@@ -49,7 +49,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
 
         authenticate {
             get("/sikret") {
-                call.respondText(text = "Du er authentisert som $authenticatedUser.", contentType = ContentType.Text.Plain)
+                call.respondText(text = "Du er autentisert", contentType = ContentType.Text.Plain)
             }
         }
     }

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/bootstrap.kt
@@ -14,7 +14,7 @@ import io.prometheus.client.hotspot.DefaultExports
 import no.nav.personbruker.tms.personalia.api.common.AuthenticatedUser
 import no.nav.personbruker.tms.personalia.api.common.AuthenticatedUserFactory
 import no.nav.personbruker.tms.personalia.api.health.healthApi
-import no.nav.security.token.support.ktor.tokenValidationSupport
+import no.nav.tms.token.support.tokenx.validation.installTokenXAuth
 
 @KtorExperimentalAPI
 fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()) {
@@ -30,12 +30,8 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
         header(HttpHeaders.ContentType)
     }
 
-    val config = this.environment.config
-
-    install(Authentication) {
-        basic {
-
-        }
+    installTokenXAuth {
+        setAsDefault = true
     }
 
     install(ContentNegotiation) {


### PR DESCRIPTION
* Åpner opp for muligheten til å snakke med tms-personalia-api via token exchange fra dittnav-api.
* La til TokendingsTokenFetcher som senere skal brukes når man veksler et token med tokendings.

Det sikrede endepunktet er testet lokalt fra terminal der det sendes med et token som er scopet til tms-personalia-api og vekslet i dittnav-api.