### PR TITLE
Setter opp to nye endepunkter som returnerer navn og ident

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/common/objectMapper.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/common/objectMapper.kt
@@ -1,0 +1,5 @@
+package no.nav.personbruker.tms.personalia.api.common
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+inline fun <reified T> ObjectMapper.readObject(string: String): T = readValue(string, T::class.java)

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/ApplicationContext.kt
@@ -1,13 +1,20 @@
 package no.nav.personbruker.tms.personalia.api.config
 
 import no.nav.personbruker.tms.personalia.api.health.HealthService
+import no.nav.personbruker.tms.personalia.api.personalia.PersonaliaConsumer
+import no.nav.personbruker.tms.personalia.api.personalia.PersonaliaService
 import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
 
 class ApplicationContext {
+    private val environment = Environment()
 
     val httpClient = HttpClientBuilder.build()
     val healthService = HealthService(this)
 
     val tokendingsService = TokendingsServiceBuilder.buildTokendingsService(maxCachedEntries = 10000)
+    val tokendingsTokenFetcher = TokendingsTokenFetcher(tokendingsService, environment.pdlClientId)
+
+    val personalieConsumer = PersonaliaConsumer(httpClient, environment.pdlUrl)
+    val personaliaService = PersonaliaService(personalieConsumer, tokendingsTokenFetcher)
 
 }

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/Environment.kt
@@ -1,7 +1,10 @@
 package no.nav.personbruker.tms.personalia.api.config
 
 import no.nav.personbruker.dittnav.common.util.config.StringEnvVar.getEnvVar
+import java.net.URL
 
 data class Environment(
     val corsAllowedOrigins: String = getEnvVar("CORS_ALLOWED_ORIGINS"),
+    val pdlUrl: URL = URL(getEnvVar("PDL_BASE_URL")),
+    val pdlClientId: String = getEnvVar("PDL_CLIENT_ID")
 )

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/JsonConfig.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/JsonConfig.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.tms.personalia.api.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.ktor.client.features.json.*
 
@@ -16,4 +17,11 @@ fun ObjectMapper.enableDittNavJsonConfig() {
     registerKotlinModule()
     registerModule(JavaTimeModule())
     disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+}
+
+object JsonDeserialize {
+    val objectMapper = ObjectMapper().apply {
+        registerModule(KotlinModule())
+        registerModule(JavaTimeModule())
+    }
 }

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/TokenDingsFetcher.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/TokenDingsFetcher.kt
@@ -4,9 +4,9 @@ import no.nav.tms.token.support.tokendings.exchange.TokendingsService
 
 class TokendingsTokenFetcher(
     private val tokendingsService: TokendingsService,
-    private val PDLClientId: String
+    private val pdlClientId: String
 ) {
-    suspend fun getPDLToken(userToken: String): String {
-        return tokendingsService.exchangeToken(userToken, PDLClientId)
+    suspend fun getPdlToken(userToken: String): String {
+        return tokendingsService.exchangeToken(userToken, pdlClientId)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/config/bootstrap.kt
@@ -6,15 +6,14 @@ import io.ktor.client.*
 import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.jackson.*
-import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.*
 import io.ktor.util.pipeline.*
 import io.prometheus.client.hotspot.DefaultExports
-import no.nav.personbruker.tms.personalia.api.common.AuthenticatedUser
-import no.nav.personbruker.tms.personalia.api.common.AuthenticatedUserFactory
 import no.nav.personbruker.tms.personalia.api.health.healthApi
+import no.nav.personbruker.tms.personalia.api.personalia.personaliaApi
 import no.nav.tms.token.support.tokenx.validation.installTokenXAuth
+import no.nav.tms.token.support.tokenx.validation.user.TokenXUserFactory
 
 @KtorExperimentalAPI
 fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()) {
@@ -43,14 +42,8 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
     routing {
         healthApi(appContext.healthService)
 
-        get("/usikret") {
-            call.respondText(text = "Usikret API.", contentType = ContentType.Text.Plain)
-        }
-
         authenticate {
-            get("/sikret") {
-                call.respondText(text = "Du er autentisert", contentType = ContentType.Text.Plain)
-            }
+            personaliaApi(appContext.personaliaService)
         }
     }
 
@@ -63,5 +56,5 @@ private fun Application.configureShutdownHook(httpClient: HttpClient) {
     }
 }
 
-val PipelineContext<Unit, ApplicationCall>.authenticatedUser: AuthenticatedUser
-    get() = AuthenticatedUserFactory.createNewAuthenticatedUser(call)
+val PipelineContext<*, ApplicationCall>.tokenXUser
+    get() = TokenXUserFactory.createTokenXUser(call)

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/PersonaliaConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/PersonaliaConsumer.kt
@@ -1,0 +1,87 @@
+package no.nav.personbruker.tms.personalia.api.personalia
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.personbruker.tms.personalia.api.common.readObject
+import no.nav.personbruker.tms.personalia.api.config.JsonDeserialize.objectMapper
+import no.nav.personbruker.tms.personalia.api.personalia.exception.PdlAuthenticationException
+import no.nav.personbruker.tms.personalia.api.personalia.exception.PdlException
+import no.nav.personbruker.tms.personalia.api.personalia.pdl.PDLErrorType
+import no.nav.personbruker.tms.personalia.api.personalia.pdl.PdlErrorResponse
+import no.nav.personbruker.tms.personalia.api.personalia.pdl.PdlPersonInfo
+import no.nav.personbruker.tms.personalia.api.personalia.pdl.PdlResponse
+import no.nav.personbruker.tms.personalia.api.personalia.query.*
+import org.slf4j.LoggerFactory
+import java.net.URL
+
+class PersonaliaConsumer (
+    private val client: HttpClient,
+    private val pdlUrl: URL
+) {
+
+    val log = LoggerFactory.getLogger(PersonaliaConsumer::class.java)
+
+    suspend fun fetchNavn(ident: String, token: String): PdlPersonInfo {
+        val request = createNavnRequest(ident)
+
+        return postPersonQuery(request, token).let { responseBody ->
+            parsePdlResponse(responseBody)
+        }
+    }
+
+    private suspend fun postPersonQuery(request: NavnRequest, token: String): String {
+        return try {
+            client.post {
+                url(pdlUrl)
+                contentType(ContentType.Application.Json)
+                bearerHeader(token)
+                temaHeader("GEN")
+                body = request
+            }
+        } catch (e: Exception) {
+            throw PdlException("Feil ved kontakt mot pdl-api", e)
+        }
+    }
+
+    private fun parsePdlResponse(json: String): PdlPersonInfo {
+        return try {
+            val personResponse: PdlResponse = objectMapper.readObject(json)
+            personResponse.data.person
+        } catch (e: Exception) {
+            handleErrorResponse(json)
+        }
+    }
+
+    private fun handleErrorResponse(json: String): Nothing {
+        try {
+            val errorResponse: PdlErrorResponse = objectMapper.readObject(json)
+            logErrorResponse(errorResponse)
+            throwAppropriateException(errorResponse)
+        } catch (e: Exception) {
+            throw PdlException("Feil ved deserialisering av svar fra pdl. Response-body lengde [${json.length}]", e)
+        }
+    }
+
+    private fun throwAppropriateException(response: PdlErrorResponse): Nothing {
+        val firstError = response.errors.first().errorType
+
+        if (firstError == PDLErrorType.NOT_AUTHENTICATED) {
+            throw PdlAuthenticationException("Fikk autentiseringsfeil mot PDL [$firstError]")
+        } else {
+            throw PdlException("Fikk feil fra pdl med type [$firstError]")
+        }
+    }
+
+    private fun logErrorResponse(response: PdlErrorResponse) {
+        val firstError = response.errors.first().errorType
+
+        when (firstError) {
+            PDLErrorType.NOT_FOUND -> log.warn("Fant ikke bruker i PDL.")
+            PDLErrorType.NOT_AUTHENTICATED -> log.warn("Autentiseringsfeil mot PDL. Feil i brukertoken eller systemtoken.")
+            PDLErrorType.ABAC_ERROR -> log.warn("Systembruker har ikke tilgang til opplysning")
+            PDLErrorType.UNKNOWN_ERROR -> log.warn("Ukjent feil mot PDL")
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/PersonaliaIdent.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/PersonaliaIdent.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.tms.personalia.api.personalia
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PersonaliaIdent(
+    val ident: String
+)

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/PersonaliaNavn.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/PersonaliaNavn.kt
@@ -1,0 +1,10 @@
+package no.nav.personbruker.tms.personalia.api.personalia
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PersonaliaNavn(
+    val fornavn: String?,
+    val mellomnavn: String?,
+    val etternavn: String?
+)

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/PersonaliaService.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/PersonaliaService.kt
@@ -1,0 +1,21 @@
+package no.nav.personbruker.tms.personalia.api.personalia
+
+import no.nav.personbruker.tms.personalia.api.config.TokendingsTokenFetcher
+import no.nav.tms.token.support.tokenx.validation.user.TokenXUser
+
+class PersonaliaService(
+    private val personaliaConsumer: PersonaliaConsumer,
+    private val tokendingsTokenFetcher: TokendingsTokenFetcher
+) {
+
+    suspend fun fetchNavn(user: TokenXUser): PersonaliaNavn {
+        val token = tokendingsTokenFetcher.getPdlToken(user.tokenString)
+        val personInfo = personaliaConsumer.fetchNavn(token, user.ident)
+
+        return personInfo.navn.first()
+    }
+
+    fun extractIdent(user: TokenXUser): PersonaliaIdent {
+        return PersonaliaIdent(user.ident)
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/exception/PdlAuthenticationException.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/exception/PdlAuthenticationException.kt
@@ -1,0 +1,6 @@
+package no.nav.personbruker.tms.personalia.api.personalia.exception
+
+class PdlAuthenticationException: PdlException {
+    constructor() : super()
+    constructor(message: String) : super(message)
+}

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/exception/PdlException.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/exception/PdlException.kt
@@ -1,0 +1,7 @@
+package no.nav.personbruker.tms.personalia.api.personalia.exception
+
+open class PdlException : Exception {
+    constructor() : super()
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/httpRequestBuilder.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/httpRequestBuilder.kt
@@ -1,0 +1,13 @@
+package no.nav.personbruker.tms.personalia.api.personalia
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+
+fun HttpRequestBuilder.bearerHeader(token: String, headerKey: String = HttpHeaders.Authorization) {
+    header(headerKey, "Bearer $token")
+}
+
+fun HttpRequestBuilder.temaHeader(temakode: String) {
+    header("Tema", temakode)
+}

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/pdl/PdlErrorResponse.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/pdl/PdlErrorResponse.kt
@@ -1,0 +1,28 @@
+package no.nav.personbruker.tms.personalia.api.personalia.pdl
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class PdlErrorResponse(val errors: List<PdlError>)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class PdlError(@JsonProperty("message") message: String) {
+
+    val errorType = PDLErrorType.fromMessage(message)
+}
+
+enum class PDLErrorType(val message: String = "") {
+    NOT_FOUND("Fant ikke person"),
+    NOT_AUTHENTICATED("Ikke autentisert"),
+    ABAC_ERROR("Ikke tilgang til å se person"),
+    UNKNOWN_ERROR;
+
+    companion object {
+        fun fromMessage(message: String): PDLErrorType {
+            return values()
+                .find { it.message == message }
+                ?: UNKNOWN_ERROR
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/pdl/PdlPersonInfo.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/pdl/PdlPersonInfo.kt
@@ -1,0 +1,5 @@
+package no.nav.personbruker.tms.personalia.api.personalia.pdl
+
+import no.nav.personbruker.tms.personalia.api.personalia.PersonaliaNavn
+
+data class PdlPersonInfo (val navn: List<PersonaliaNavn>)

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/pdl/PdlResponse.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/pdl/PdlResponse.kt
@@ -1,0 +1,9 @@
+package no.nav.personbruker.tms.personalia.api.personalia.pdl
+
+data class PdlResponse(
+    val data: PdlData
+)
+
+data class PdlData (
+    val person: PdlPersonInfo
+)

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/personaliaApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/personaliaApi.kt
@@ -1,0 +1,35 @@
+package no.nav.personbruker.tms.personalia.api.personalia
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.personbruker.tms.personalia.api.config.tokenXUser
+import org.slf4j.LoggerFactory
+
+fun Route.personaliaApi(personaliaService: PersonaliaService) {
+
+    val log = LoggerFactory.getLogger(PersonaliaService::class.java)
+
+    get("/navn") {
+        try {
+            val result = personaliaService.fetchNavn(tokenXUser)
+            call.respond(HttpStatusCode.OK, result)
+
+        } catch (exception: Exception) {
+            call.respond(HttpStatusCode.InternalServerError)
+            log.warn("Klarte ikke å hente navn. $exception.message", exception)
+        }
+    }
+
+    get("/ident") {
+        try {
+            val result = personaliaService.extractIdent(tokenXUser)
+            call.respond(HttpStatusCode.OK, result)
+
+        } catch (exception: Exception) {
+            call.respond(HttpStatusCode.InternalServerError)
+            log.warn("Klarte ikke å hente ident. $exception.message", exception)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/query/NavnRequest.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/query/NavnRequest.kt
@@ -1,0 +1,21 @@
+package no.nav.personbruker.tms.personalia.api.personalia.query
+
+class NavnRequest(val variables: QueryVariables) {
+
+    val query: String
+        get() = """
+            query (${"$"}ident: ID!) {
+                person: hentPerson(ident: ${"$"}ident) {
+                     navn { fornavn, mellomnavn, etternavn }
+                } 
+            }
+        """.compactJson()
+}
+
+fun createNavnRequest(ident: String): NavnRequest {
+    return NavnRequest(QueryVariables(ident))
+}
+
+private fun String.compactJson(): String =
+    trimIndent().replace("\r", " ").replace("\n", " ").replace("\\s+".toRegex(), " ")
+

--- a/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/query/QueryVariables.kt
+++ b/src/main/kotlin/no/nav/personbruker/tms/personalia/api/personalia/query/QueryVariables.kt
@@ -1,0 +1,5 @@
+package no.nav.personbruker.tms.personalia.api.personalia.query
+
+data class QueryVariables (
+    val ident: String
+)


### PR DESCRIPTION
Setter opp to nye endepunkter som returnerer navn og ident. Navnet hentes fra PDL med en GrahpQL spørring. I første omgang returnerer endepunktet /navn navnet delt opp i fornavn, mellomnavn og etternavn. Kommer til å merge de sammen i en annen PR 😊  